### PR TITLE
Automagic group declaration

### DIFF
--- a/CANalyzer/load.py
+++ b/CANalyzer/load.py
@@ -37,6 +37,7 @@ class Load:
 
         if self.groups:
             rawgroups = ast.literal_eval(self.groups)
+            rawgroups['undef'] = ''
             self.groupnames = rawgroups.keys()
             grouprange = []
             for key in self.groupnames:

--- a/CANalyzer/mo.py
+++ b/CANalyzer/mo.py
@@ -93,6 +93,7 @@ class MO(Load):
 
 
     def identify_group(self, atom_number):
+        group='undef'
         for name in self.groupnames:
             grouprange = self.groups[name]
             for r in grouprange:


### PR DESCRIPTION
Automatically add all atoms to the 'undef' group so don't need to explicitly add.